### PR TITLE
ci: allow manual runs via workflow_dispatch

### DIFF
--- a/.github/workflows/integrity-build-gate.yml
+++ b/.github/workflows/integrity-build-gate.yml
@@ -1,6 +1,7 @@
 name: Integrity Build Gate
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "main" ]
   push:

--- a/.github/workflows/jb-cli-smoke.yml
+++ b/.github/workflows/jb-cli-smoke.yml
@@ -1,6 +1,7 @@
 name: JB CLI Smoke
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "main" ]
   push:


### PR DESCRIPTION
Adds workflow_dispatch to JB CLI Smoke and Integrity Build Gate so gh workflow run works.